### PR TITLE
Nascowe/add otel headers

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "browser-sdk",
   "description": "browser SDK",
   "private": true,
+  "version": "4.7.0a",
   "workspaces": [
     "packages/*",
     "developer-extension",

--- a/packages/rum-core/src/domain/tracing/tracer.spec.ts
+++ b/packages/rum-core/src/domain/tracing/tracer.spec.ts
@@ -329,6 +329,7 @@ function tracingHeadersFor(traceId: TraceIdentifier, spanId: TraceIdentifier) {
     'x-datadog-sampled': '1',
     'x-datadog-sampling-priority': '1',
     'x-datadog-trace-id': traceId.toDecimalString(),
+    'traceparent': '01-0000000000000000'+BigInt(traceId.toDecimalString()).toString(16)+'-'+BigInt(spanId.toDecimalString()).toString(8)+’-01',
   }
 }
 

--- a/packages/rum-core/src/domain/tracing/tracer.ts
+++ b/packages/rum-core/src/domain/tracing/tracer.ts
@@ -120,6 +120,7 @@ function makeTracingHeaders(traceId: TraceIdentifier, spanId: TraceIdentifier): 
     'x-datadog-sampled': '1',
     'x-datadog-sampling-priority': '1',
     'x-datadog-trace-id': traceId.toDecimalString(),
+    'traceparent': '01-0000000000000000'+BigInt(traceId.toDecimalString()).toString(16)+'-'+BigInt(spanId.toDecimalString()).toString(8)+’-01',
   }
 }
 


### PR DESCRIPTION
## Motivation

Correlate RUM to traces collected by open telemetry tracers

## Changes

It generates a traceparent header using the datadog trace id converted to hex, but prefixed by 16 0s as Datadog only uses the last 16 characters of an otel trace id to generate the datadog trace id. 

## Testing

There are no tests for otel; this is purely hypothetical.
